### PR TITLE
Refactored todos management strategy from dynamic indexing to ID-based lookup

### DIFF
--- a/components/core/todo-list/index.jsx
+++ b/components/core/todo-list/index.jsx
@@ -70,18 +70,18 @@ export const TodoList = () => {
       )}
       <div className={`${isMobile && 'todo-container'}`}>
         {items.length > 0 ? (
-          items.map((item, index) => {
+          items.map((item) => {
             return (
               <motion.div
-                key={index}
+                key={item.id}
                 initial={{ opacity: 0, y: -20 }}
                 animate={{ opacity: 1, y: 0 }}
                 exit={{ opacity: 0, y: -20 }}
                 transition={{ duration: 0.5 }}
               >
                 <Todo
-                  key={index}
-                  index={index}
+                  key={item.id}
+                  id={item.id}
                   task={item.task}
                   deleteItem={deleteItem}
                 />

--- a/components/core/todo-list/todo.jsx
+++ b/components/core/todo-list/todo.jsx
@@ -3,13 +3,14 @@ import { Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useLocalStorage } from '@/hooks/use-local-storage';
 
-export const Todo = ({ task, index, deleteItem }) => {
+export const Todo = ({ task, id, deleteItem }) => {
   const { checkCompleted, items } = useLocalStorage('my-tasks');
 
-  const isCompleted = items?.[index]?.isCompleted;
+  const isCompleted =
+    items.find((item) => item.id === id)?.isCompleted ?? false;
 
   const handleDeleteTask = () => {
-    deleteItem(index);
+    deleteItem(id);
     toast.info('Task deleted successfully');
   };
 
@@ -20,7 +21,7 @@ export const Todo = ({ task, index, deleteItem }) => {
           <div className="flex items-center gap-2">
             <div className="flex items-center">
               <Checkbox
-                onCheckedChange={() => checkCompleted(index)}
+                onCheckedChange={() => checkCompleted(id)}
                 checked={isCompleted}
                 className="rounded-xl w-[17px] h-[17px]"
               />

--- a/hooks/use-local-storage.js
+++ b/hooks/use-local-storage.js
@@ -17,25 +17,24 @@ export const useLocalStorage = (key) => {
     setItems(updatedItems);
   };
 
-  const deleteItem = (index) => {
-    const updatedItems = items.filter((_, i) => i !== index);
+  const deleteItem = (id) => {
+    const updatedItems = items.filter((item) => item.id !== id);
     localStorage.setItem(key, JSON.stringify(updatedItems));
     setItems(updatedItems);
   };
 
-  const updateItem = (index, newTask) => {
-    const updatedItems = [...items];
-    updatedItems[index] = {
-      task: newTask,
-      isCompleted: updatedItems[index].isCompleted,
-    };
+  const updateItem = (id, newTask) => {
+    const updatedItems = items.map((item) =>
+      item.id === id ? { ...item, task: newTask } : item
+    );
     localStorage.setItem(key, JSON.stringify(updatedItems));
     setItems(updatedItems);
   };
 
-  const checkCompleted = (index) => {
-    const updatedItems = [...items];
-    updatedItems[index].isCompleted = !updatedItems[index].isCompleted;
+  const checkCompleted = (id) => {
+    const updatedItems = items.map((item) =>
+      item.id === id ? { ...item, isCompleted: !item.isCompleted } : item
+    );
     localStorage.setItem(key, JSON.stringify(updatedItems));
     setItems(updatedItems);
   };


### PR DESCRIPTION
#1  
An issue where deleting a todo marked as completed would inadvertently affect the "new first in order" todo. To resolve this issue, I've refactored todos management strategy from dynamic indexing to a more robust ID-based lookup approach. This ensured that the deletion of completed todo does not disrupt the order of active todos.